### PR TITLE
Allow URL-encoded species identifiers

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
 #Wed Jul 08 16:11:28 BST 2015
-app.grails.version=2.4.4
+app.grails.version=2.5.1
 app.name=bie-plugin

--- a/grails-app/conf/BiePluginUrlMappings.groovy
+++ b/grails-app/conf/BiePluginUrlMappings.groovy
@@ -7,7 +7,7 @@ class BiePluginUrlMappings {
             }
         }
         // Redirects for BIE web services URLs
-        "/species/$guid"(controller: "species", action: "show")
+        "/species/$guid**"(controller: "species", action: "show")
         "/search"(controller: "species", action: "search")
         "/image-search"(controller: "species", action: "imageSearch")
         "/image-search/showSpecies"(controller: "species", action: "imageSearch")

--- a/grails-app/conf/defaultConfig.groovy
+++ b/grails-app/conf/defaultConfig.groovy
@@ -1,7 +1,7 @@
 runWithNoExternalConfig = true
 projectNameShort = "Atlas"
 projectName = "Atlas of Living Australia"
-bie.baseURL = "http://bie.ala.org.au"
+bie.baseURL = "http://localhost:8080/bie-plugin"
 bie.searchPath = "/search"
 biocache.baseURL = "http://biocache.ala.org.au"
 biocacheService.baseURL = "http://biocache.ala.org.au/ws"
@@ -17,7 +17,7 @@ sightings.guidUrl = "http://sightings.ala.org.au/"
 collectory.threatenedSpeciesCodesUrl = collectory.baseURL + "/public/showDataResource"
 skin.layout = "generic"
 eol.lang = "en"
-bie.index.url = "http://localhost:8080/bie-index"
+bie.index.url = "http://localhost:8090/bie-index"
 defaultDecimalLatitude = -27.7
 defaultDecimalLongitude = 133.8
 defaultZoomLevel = 4

--- a/grails-app/views/species/search.gsp
+++ b/grails-app/views/species/search.gsp
@@ -206,9 +206,7 @@
                                 </g:if>
 
                                 <h3>${result.rank}:
-                                    <a href="${speciesPageLink}"><bie:formatSciName rankId="${result.rankID}"
-                                                       name="${(result.nameComplete) ? result.nameComplete : result.name}"
-                                                       acceptedName="${result.acceptedConceptName}"/></a>
+                                    <a href="${speciesPageLink}"><bie:formatSciName rankId="${result.rankID}" nameFormatted="${result.nameFormatted}" nameComplete="${result.nameComplete}" name="${result.name}" acceptedName="${result.acceptedConceptName}"/></a>
                                     <g:if test="${result.commonNameSingle}"><span class="commonNameSummary">&nbsp;&ndash;&nbsp;${result.commonNameSingle}</span></g:if>
                                 </h3>
                                 <g:if test="${result.commonName != result.commonNameSingle}"><p class="alt-names">${result.commonName}</p></g:if>

--- a/grails-app/views/species/show.gsp
+++ b/grails-app/views/species/show.gsp
@@ -21,7 +21,7 @@
 <g:set var="citizenSciUrl" value="${grailsApplication.config.sightings.guidUrl}"/>
 <g:set var="alertsUrl" value="${grailsApplication.config.alerts.url}"/>
 <g:set var="guid" value="${tc?.previousGuid?:tc?.taxonConcept?.guid?:''}"/>
-<g:set var="sciNameFormatted"><bie:formatSciName name="${tc?.taxonConcept?.nameString}" rankId="${tc?.taxonConcept?.rankID?:0}"/></g:set>
+<g:set var="sciNameFormatted"><bie:formatSciName rankId="${tc?.taxonConcept?.rankID}" nameFormatted="${tc?.taxonConcept?.nameFormatted}" nameComplete="${tc?.taxonConcept?.nameComplete}" name="${tc?.taxonConcept?.name}" acceptedName="${tc?.taxonConcept?.acceptedConceptName}"/></g:set>
 <g:set var="synonymsQuery"><g:each in="${tc?.synonyms}" var="synonym" status="i">\"${synonym.nameString}\"<g:if test="${i < tc.synonyms.size() - 1}"> OR </g:if></g:each></g:set>
 <!DOCTYPE html>
 <html lang="en">
@@ -51,9 +51,7 @@
             </div>
             </g:if>
             <div class="header-inner">
-                <h1>
-                    <bie:formatSciName name="${tc?.taxonConcept?.nameString}" rankId="${tc?.taxonConcept?.rankID?:0}"/>
-                    <span>${tc?.taxonConcept?.author?:""}</span></h1>
+                <h1><bie:formatSciName rankId="${tc?.taxonConcept?.rankID}" nameFormatted="${tc?.taxonConcept?.nameFormatted}" nameComplete="${tc?.taxonConcept?.nameComplete}" name="${tc?.taxonConcept?.name}" acceptedName="${tc?.taxonConcept?.acceptedConceptName}"/></h1>
                 <g:set var="commonNameDisplay" value="${(tc?.commonNames) ? tc?.commonNames?.opt(0)?.nameString : ''}"/>
                 <g:if test="${commonNameDisplay}">
                     <h2>${commonNameDisplay}</h2>
@@ -189,10 +187,10 @@
                                         <p><a class="tab-link" href="#data-providers">Browse the list of data providers</a> and find organisations you can join if you are
                                         interested in participating in a survey for
                                         <g:if test="${tc.taxonConcept?.rankID > 6000}">
-                                            species like ${sciNameFormatted}
+                                            species like ${raw(sciNameFormatted)}
                                         </g:if>
                                         <g:else>
-                                            species of ${sciNameFormatted}.
+                                            species of ${raw(sciNameFormatted)}.
                                         </g:else>
                                         </p>
                                     </div>
@@ -236,7 +234,7 @@
                         </thead>
                         <tbody>
                             <tr>
-                                <td><bie:formatSciName name="${tc?.taxonConcept?.nameString}" rankId="${tc?.taxonConcept?.rankID?:0}"/> ${authorship}</td>
+                                <td><bie:formatSciName rankId="${tc?.taxonConcept?.rankID}" nameFormatted="${tc?.taxonConcept?.nameFormatted}" nameComplete="${tc?.taxonConcept?.nameComplete}" name="${tc?.taxonConcept?.name}" acceptedName="${tc?.taxonConcept?.acceptedConceptName}"/></td>
                                 <td class="source">
                                     <ul><li><a href="${tc.taxonConcept.infoSourceURL}" target="_blank" class="external">${tc.taxonConcept.nameAuthority}</a></li></ul>
                                 </td>
@@ -262,7 +260,7 @@
                             <tbody>
                                 <g:each in="${tc.synonyms}" var="synonym">
                                     <tr>
-                                        <td><bie:formatSciName name="${synonym.nameString}" rankId="${tc.taxonConcept?.rankID}"/> ${synonym.author}</td>
+                                        <td><bie:formatSciName rankId="${tc?.taxonConcept?.rankID}" nameFormatted="${synonym.nameFormatted}" nameComplete="${synonym.nameComplete}" name="${synonym.nameString}"/></td>
                                         <td class="source">
                                             <ul>
                                                 <g:if test="${!synonym.infoSourceURL}"><li><a href="${tc.taxonConcept.infoSourceURL}" target="_blank" class="external">${tc.taxonConcept.infoSourceName}</a></li></g:if>
@@ -341,15 +339,15 @@
                         <g:each in="${taxonHierarchy}" var="taxon">
                             <!-- taxon = ${taxon} -->
                             <g:if test="${taxon.guid != tc.taxonConcept.guid}">
-                                <dl><dt><g:if test="${taxon.rankId?:0 !=0}">${taxon.rank}</g:if></dt>
+                                <dl><dt><g:if test="${taxon.rankID?:0 !=0}">${taxon.rank}</g:if></dt>
                                 <dd><a href="${request?.contextPath}/species/${taxon.guid}#classification" title="${taxon.rank}">
-                                    <bie:formatSciName name="${taxon.scientificName}" rankId="${taxon.rankId?:0}"/>
+                                    <bie:formatSciName rankId="${taxon.rankID}" nameFormatted="${taxon.nameFormatted}" nameComplete="${taxon.nameComplete}" name="${taxon.scientificName}"/>
                                     <g:if test="${taxon.commonNameSingle}">: ${taxon.commonNameSingle}</g:if></a>
                                 </dd>
                             </g:if>
                             <g:elseif test="${taxon.guid == tc.taxonConcept.guid}">
                                 <dl><dt id="currentTaxonConcept">${taxon.rank}</dt>
-                                <dd><span><bie:formatSciName name="${taxon.scientificName}" rankId="${taxon.rankId?:0}"/>
+                                <dd><span><bie:formatSciName rankId="${taxon.rankID}" nameFormatted="${taxon.nameFormatted}" nameComplete="${taxon.nameComplete}" name="${taxon.scientificName}"/>
                                     <g:if test="${taxon.commonNameSingle}">: ${taxon.commonNameSingle}</g:if></span>
                                 </dd>
                             </g:elseif>
@@ -360,9 +358,8 @@
                             <g:each in="${childConcepts}" var="child" status="i">
                                 <g:set var="currentRank" value="${child.rank}"/>
                                 <dt>${child.rank}</dt>
-                                <g:set var="taxonLabel"><bie:formatSciName name="${child.nameComplete ? child.nameComplete : child.name}"
-                                                                           rankId="${child.rankId?:0}"/><g:if test="${child.commonNameSingle}">: ${child.commonNameSingle}</g:if></g:set>
-                                <dd><a href="${request?.contextPath}/species/${child.guid}#classification">${taxonLabel.trim()}</a>&nbsp;
+                                <g:set var="taxonLabel"><bie:formatSciName rankId="${child.rankID}" nameFormatted="${child.nameFormatted}" nameComplete="${child.nameComplete}" name="${child.name}"/><g:if test="${child.commonNameSingle}">: ${child.commonNameSingle}</g:if></g:set>
+                                <dd><a href="${request?.contextPath}/species/${child.guid}#classification">${raw(taxonLabel.trim())}</a>&nbsp;
                                 </dd>
                             </g:each>
                         </dl>

--- a/web-app/css/atlas.css
+++ b/web-app/css/atlas.css
@@ -131,6 +131,12 @@ html, body {height:100%;}
 .push {clear:both;}
 
 
+/* Name formatting */
+
+.scientific-name { font-style: normal; }
+.scientific-name.rank-genus .name { font-style: italic; }
+.scientific-name.rank-species .name { font-style: italic; }
+.scientific-name.rank-subspecies .name { font-style: italic; }
 
 /* Media Queries
 ================================================== */


### PR DESCRIPTION
Some taxa now have URL-encoded identifiers, rather than LSIDs. For example, http://biodiversity.org.au/apc/2888571

These now need to be looked up in the bie-plugin service as something like http://host/bie/species/http://biodiversity.org.au/apc/4769509 or http://host/bie-index/taxon/http%3A%2F%2Fbiodiversity.org.au%2Fapc%2F2888571 if the ID is URL-encoded.

This fix allows the full ID with slashes to be interpreted as an ID.

Note that tomcat doesn't like encoded slashes by default and rejects URLs with them. To override this behaviour use  -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true

See https://github.com/AtlasOfLivingAustralia/bie-index/pull/38