### PR TITLE
* Allow ordered common names

### DIFF
--- a/grails-app/controllers/au/org/ala/bie/SpeciesController.groovy
+++ b/grails-app/controllers/au/org/ala/bie/SpeciesController.groovy
@@ -16,6 +16,7 @@
 package au.org.ala.bie
 
 import org.codehaus.groovy.grails.web.json.JSONObject
+import org.springframework.web.servlet.support.RequestContextUtils
 
 /**
  * Species Controller
@@ -97,19 +98,19 @@ class SpeciesController {
             render(view: '../error', model: [message: etc.error])
         } else {
             render(view: 'show', model: [
-                tc: etc,
-                statusRegionMap: utilityService.getStatusRegionCodes(),
-                infoSourceMap:[],
+                    tc: etc,
+                    statusRegionMap: utilityService.getStatusRegionCodes(),
+                    infoSourceMap:[],
 //                extraImages: bieService.getExtraImages(etc),
-                textProperties: [],
-                isAustralian: false,
-                isRoleAdmin: false, //authService.userInRole(grailsApplication.config.auth.admin_role),
-                userName: "",
-                isReadOnly: grailsApplication.config.ranking.readonly,
-                sortCommonNameSources: utilityService.getNamesAsSortedMap(etc.commonNames),
-                taxonHierarchy: bieService.getClassificationForGuid(etc.taxonConcept.guid),
-                childConcepts: bieService.getChildConceptsForGuid(etc.taxonConcept.guid),
-                speciesList: bieService.getSpeciesList(etc.taxonConcept?.guid?:guid)
+                    textProperties: [],
+                    isAustralian: false,
+                    isRoleAdmin: false, //authService.userInRole(grailsApplication.config.auth.admin_role),
+                    userName: "",
+                    isReadOnly: grailsApplication.config.ranking.readonly,
+                    sortCommonNameSources: utilityService.getNamesAsSortedMap(etc.commonNames),
+                    taxonHierarchy: bieService.getClassificationForGuid(etc.taxonConcept.guid),
+                    childConcepts: bieService.getChildConceptsForGuid(etc.taxonConcept.guid),
+                    speciesList: bieService.getSpeciesList(etc.taxonConcept?.guid?:guid)
             ])
         }
     }

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -119,6 +119,8 @@ idxtype.DATARESOURCE=Data resource
 idxtype.REGION=Region
 idxtype.WORDPRESS=Site Page
 idxtype.LAYER=Spatial layer
+idxtype.COMMON=Common Name
+idxtype.IDENTIFIER=Species Identifier
 
 region.Australia=AU
 region.South\ Australia=SA

--- a/grails-app/services/au/org/ala/bie/UtilityService.groovy
+++ b/grails-app/services/au/org/ala/bie/UtilityService.groovy
@@ -78,16 +78,18 @@ class UtilityService {
         infoSourceMap
     }
 
-    def unDuplicateNames(names) {
+    def unDuplicateNames(List names) {
         def namesSet = []
+        def seen = [] as Set
 
-        names.eachWithIndex { it, i ->
-            if (names.length() == 1 || normaliseString(it.nameString) != normaliseString(names[i - 1]?.nameString)
-                    || it.infoSourceName != names[i - 1]?.infoSourceName) {
-                namesSet.add(it)
-            } else {
-                log.debug i + " dupe not added: "  + normaliseString(it.nameString) + "=" + it.infoSourceName + " | " +
-                        normaliseString(names[i - 1]?.nameString) + "=" + names[i - 1]?.infoSourceName
+        names = names.sort(false, { n -> - n.priority })
+        names.each { name ->
+            def key = normaliseString(name.nameString) + "=" + name.infoSourceName
+            if (seen.contains(key))
+                log.debug(" dupe not added: " + key)
+            else {
+                namesSet.add(name)
+                seen.add(key)
             }
         }
         log.debug "namesSet: ${namesSet}"
@@ -95,7 +97,9 @@ class UtilityService {
     }
 
     /**
-     * Group names which are equivalent into a map with a list of their name objects
+     * Group names which are equivalent into a map with a list of their name objects.
+     * <p>
+     * The keys are sorted by name priority
      *
      * @param names
      * @return

--- a/grails-app/views/species/search.gsp
+++ b/grails-app/views/species/search.gsp
@@ -224,6 +224,16 @@
                                     </g:if>
                                 </ul>
                             </g:if>
+                            <g:elseif test="${result.has("idxtype") && result.idxtype == 'COMMON'}">
+                                <g:set var="speciesPageLink">${request.contextPath}/species/${result.linkIdentifier?:result.taxonGuid}</g:set>
+                                <h4><g:message code="idxtype.${result.idxtype}" default="${result.idxtype}"/>:
+                                    <a href="${speciesPageLink}">${result.name}</a></h4>
+                            </g:elseif>
+                            <g:elseif test="${result.has("idxtype") && result.idxtype == 'IDENTIFIER'}">
+                                <g:set var="speciesPageLink">${request.contextPath}/species/${result.linkIdentifier?:result.taxonGuid}</g:set>
+                                <h4><g:message code="idxtype.${result.idxtype}" default="${result.idxtype}"/>:
+                                    <a href="${speciesPageLink}">${result.guid}</a></h4>
+                            </g:elseif>
                             <g:elseif test="${result.has("idxtype") && result.idxtype == 'REGION'}">
                                 <h4><g:message code="idxtype.${result.idxtype}" default="${result.idxtype}"/>:
                                     <a href="${grailsApplication.config.regions.baseURL}/feature/${result.guid}">${result.name}</a></h4>

--- a/web-app/css/atlas.css
+++ b/web-app/css/atlas.css
@@ -37,6 +37,7 @@ a.expand-options {border-top: 1px solid #e3e3e3; display: block; padding-top: 2p
 .search-results-list {border-bottom: 1px solid #ddd;}
 .search-result {border-top: 1px solid #ddd; padding-top: 16px; padding-bottom: 15px;}
 .search-result h3 {font-size: 17px; line-height: 21px; margin-bottom: 5px; margin-top: 0;}
+.search-result h4 {font-size: 15px; line-height: 20px; margin-bottom: 5px; margin-top: 0;}
 .search-result p {margin-bottom: 5px;}
 .result-thumbnail {float: right; margin: 4px 0px 5px 20px;}
 .result-thumbnail a {display: block;}


### PR DESCRIPTION
* Allow additional identifiers
* Ensure fields supplied by bie-index and fields used in show.gsp match

See https://github.com/AtlasOfLivingAustralia/bie-index/pull/43 for matching bie-index pull request