### PR TITLE
HTML encoded &, = and : doesn't work with SOLR

### DIFF
--- a/grails-app/services/au/org/ala/bie/BieService.groovy
+++ b/grails-app/services/au/org/ala/bie/BieService.groovy
@@ -16,12 +16,12 @@ class BieService {
 
         //add a query context for BIE - to reduce taxa to a subset
         if(grailsApplication.config.bieService.queryContext){
-            queryUrl = queryUrl + "&" + URLEncoder.encode(grailsApplication.config.bieService.queryContext, "UTF-8")
+            queryUrl = queryUrl + "&" + grailsApplication.config.bieService.queryContext.replaceAll(" ","%20")
         }
 
         //add a query context for biocache - this will influence record counts
         if(grailsApplication.config.biocacheService.queryContext){
-            queryUrl = queryUrl + "&bqc=" + URLEncoder.encode(grailsApplication.config.biocacheService.queryContext, "UTF-8")
+            queryUrl = queryUrl + "&bqc=" + (grailsApplication.config.biocacheService.queryContext).replaceAll(" ","%20")
         }
 
         def json = webService.get(queryUrl)


### PR DESCRIPTION
e.g. if bie-config.properties entry is as follows, then encoding means that the parameters are ignored:
bieService.queryContext = fq\=-idxtype:COMMON&fq\=establishmentMeans:introduced
the encoded call to bie-index looks like:
https://species-ws.nbnatlas.org/search?q=pea&start=0&rows=0&sort=&dir=desc&facets=idxtype&fq%3D-idxtype%3ACOMMON%26fq%3DestablishmentMeans%3Aintroduced

it should be:
https://species-ws.nbnatlas.org/search?q=pea&start=0&rows=0&sort=&dir=desc&facets=idxtype&fq=-idxtype:COMMON&fq=establishmentMeans:introduced