### PR TITLE
Prevent resetting of rows per page

### DIFF
--- a/grails-app/assets/javascripts/search.js
+++ b/grails-app/assets/javascripts/search.js
@@ -97,6 +97,8 @@ function reloadWithParam(paramName, paramValue) {
     var fqList = $.getQueryParam('fq'); //$.query.get('fq');
     var sort = $.getQueryParam('sortField');
     var dir = $.getQueryParam('dir');
+    var rows = $.getQueryParam('rows');
+    
     // add query param
     if (q != null) {
         paramList.push("q=" + q);
@@ -112,6 +114,10 @@ function reloadWithParam(paramName, paramValue) {
     // add dir param if already set
     if (paramName != 'dir' && dir != null) {
         paramList.push('dir' + "=" + dir);
+    }
+    // add rows param if already set
+    if (paramName != 'rows' && rows != null) {
+        paramList.push('rows' + "=" + rows);
     }
     // add the changed value
     if (paramName != null && paramValue != null) {


### PR DESCRIPTION
When user changes sort-by or sort order, this was resetting to default (10) rows per page