### PR TITLE
Sound search uses taxon ID, rather than name.

### DIFF
--- a/grails-app/controllers/au/org/ala/bie/SpeciesController.groovy
+++ b/grails-app/controllers/au/org/ala/bie/SpeciesController.groovy
@@ -180,7 +180,10 @@ class SpeciesController {
     }
 
     def soundSearch = {
-        JSONObject result = biocacheService.getSoundsForTaxon(params.s)
+        JSONObject result = new JSONObject()
+        if (params.id) {
+            result = biocacheService.getSoundsForTaxon(params.id)
+        }
         render(text: result.toString(), contentType: "application/json", encoding: "UTF-8")
     }
 

--- a/grails-app/services/au/org/ala/bie/BiocacheService.groovy
+++ b/grails-app/services/au/org/ala/bie/BiocacheService.groovy
@@ -15,11 +15,11 @@ class BiocacheService {
      * @param taxonName
      * @return
      */
-    def getSoundsForTaxon(taxonName){
+    def getSoundsForTaxon(taxonID){
         JSONObject jsonObj = new JSONObject()
         if (!grailsApplication.config.biocacheService.baseURL)
             return jsonObj
-        def queryUrl = grailsApplication.config.biocacheService.baseURL + "/occurrences/search?q=" + URIUtil.encodeWithinQuery(taxonName, "UTF-8") + "&fq=multimedia:Sound"
+        def queryUrl = grailsApplication.config.biocacheService.baseURL + "/occurrences/search?q=" + URIUtil.encodeWithinQuery("lsid:\"${taxonID}\"", "UTF-8") + "&fq=multimedia:Sound"
 
         log.debug "calling url = ${queryUrl}"
         def data = webService.getJson(queryUrl)

--- a/grails-app/views/species/show.gsp
+++ b/grails-app/views/species/show.gsp
@@ -376,7 +376,7 @@
         eolUrl:             "${raw(createLink(controller: 'externalSite', action: 'eol', params: [s: tc?.taxonConcept?.nameString ?: '', f:tc?.classification?.class?:tc?.classification?.phylum?:'']))}",
         genbankUrl:         "${raw(createLink(controller: 'externalSite', action: 'genbank', params: [s: tc?.taxonConcept?.nameString ?: '']))}",
         scholarUrl:         "${raw(createLink(controller: 'externalSite', action: 'scholar', params: [s: tc?.taxonConcept?.nameString ?: '']))}",
-        soundUrl:           "${raw(createLink(controller: 'species', action: 'soundSearch', params: [s: tc?.taxonConcept?.nameString ?: '']))}",
+        soundUrl:           "${raw(createLink(controller: 'species', action: 'soundSearch', params: [id: guid]))}",
         eolLanguage:        "${grailsApplication.config.eol.lang}",
         defaultDecimalLatitude: ${grailsApplication.config.defaultDecimalLatitude},
         defaultDecimalLongitude: ${grailsApplication.config.defaultDecimalLongitude},


### PR DESCRIPTION
This prevents strange matches based on a simple name search in the biocache resulting in plants (that are not Triffids) having calls