### PR TITLE
Fix #176 : BHL domain name update

### DIFF
--- a/grails-app/views/species/_literature.gsp
+++ b/grails-app/views/species/_literature.gsp
@@ -16,9 +16,9 @@
         <div class="col-md-9" style="padding-top:14px;">
 
             <div id="bhl-integration">
-                <h3>Name references found in the <a href="http://biodiversityheritagelibrary.com/" target="_blank">Biodiversity Heritage Library</a></h3>
+                <h3>Name references found in the <a href="https://www.biodiversitylibrary.org/" target="_blank">Biodiversity Heritage Library</a></h3>
                 <div id="bhl-results-list" class="result-list">
-                    <a href='http://www.biodiversitylibrary.org/search?SearchTerm=%22${synonyms?.join('%22+OR+%22')}%22&SearchCat=M#/names' target='bhl'>Search BHL for references to ${tc?.taxonConcept?.nameString}</a>
+                    <a href='https://www.biodiversitylibrary.org/search?SearchTerm=%22${synonyms?.join('%22+OR+%22')}%22&SearchCat=M#/names' target='bhl'>Search BHL for references to ${tc?.taxonConcept?.nameString}</a>
                 </div>
             </div>
 


### PR DESCRIPTION
The result list had been changed, but the other link had not.

Also switch to HTTPS, which is supported for `www.biodiversitylibrary.org`