### PR TITLE
Update charts plugin with i18n support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     compile group: 'org.grails.plugins', name: 'ala-bootstrap3', version: '3.2.3'
     compile group: 'org.grails.plugins', name: 'ala-auth', version:'3.1.3'
     compile group: 'au.org.ala.plugins.grails', name: 'ala-citation-plugin', version: '1.0'
-    runtime group: 'au.org.ala.plugins.grails', name: 'ala-charts-plugin', version: '2.1'
+    runtime group: 'au.org.ala.plugins.grails', name: 'ala-charts-plugin', version: '2.1.2'
     compile group: 'au.org.ala.plugins.grails', name: 'images-client-plugin', version: '1.2'
     compile "au.org.ala:data-quality-filter-service-client:1.0.0"
 }

--- a/grails-app/init/bie/plugin/BootStrap.groovy
+++ b/grails-app/init/bie/plugin/BootStrap.groovy
@@ -19,7 +19,8 @@ class BootStrap {
                 "file:///var/opt/atlas/i18n/bie-plugin/messages",
                 "file:///opt/atlas/i18n/bie-plugin/messages",
                 "classpath:grails-app/i18n/messages",
-                "classpath:messages"
+                "classpath:messages",
+                "${grailsApplication.config.biocacheService.baseURL}/facets/i18n"
         )
         Object.metaClass.trimLength = { Integer stringLength ->
 


### PR DESCRIPTION
Using the [PR](https://github.com/AtlasOfLivingAustralia/ala-charts-plugin/pull/8) from @biodivAtlasAT with this PR charts are translated too:

![image](https://user-images.githubusercontent.com/180085/161050693-33702586-ab26-4db4-802a-7402aa44ac31.png)

Also included in:
https://github.com/AtlasOfLivingAustralia/collectory/pull/93

It gets the translations from i18n messages from biocache-service.

Closes #264.
